### PR TITLE
Fixes by Zioth

### DIFF
--- a/style.css
+++ b/style.css
@@ -16,6 +16,18 @@ div.menuright {
     float:right
 }
 
+div.menuvtop .menuitem {
+    align-items:flex-start;
+}
+
+div.menuvcenter .menuitem {
+    align-items:center;
+}
+
+div.menuvbottom .menuitem {
+    align-items:flex-end;
+}
+
 div.menuitem {
     display:flex;
     align-items:flex-start;

--- a/style.css
+++ b/style.css
@@ -1,25 +1,25 @@
 
 div.menu {
-    text-align:left;
+    display:flex;
+    flex-wrap:wrap;
 }
 
 div.menucenter {
-    margin:auto;
+    margin: auto;
 }
 
 div.menuleft {
-    margin:0;
     float:left
 }
 
 div.menuright {
-    margin:0;
     float:right
 }
 
 div.menuitem {
-    float:left;
-    padding:5px 5px 0 0;
+    display:inline-block;
+    vertical-align:top;
+    text-align:left;
 }
 
 div.menu p.caption {
@@ -49,6 +49,7 @@ div.menu p.menudesc {
 }
 
 div#menu ul.menubar {
+    display:flex;
     padding:0;
     margin:0;
     list-style:none !important;
@@ -56,10 +57,16 @@ div#menu ul.menubar {
 
 div#menu ul.menubar li {
     border:none;
-    float:left;
+}
+div#menu ul.menubar li:not(:last-child) {
     margin-right:8px;
 }
 
 div#menu ul.menubar li a {
     text-decoration:none;
+}
+
+div.menutextcontainer {
+    display: flex;
+    flex-flow: column;
 }

--- a/style.css
+++ b/style.css
@@ -17,8 +17,8 @@ div.menuright {
 }
 
 div.menuitem {
-    display:inline-block;
-    vertical-align:top;
+    display:flex;
+    align-items:flex-start;
     text-align:left;
 }
 

--- a/syntax.php
+++ b/syntax.php
@@ -63,7 +63,7 @@ class syntax_plugin_menu extends DokuWiki_Syntax_Plugin {
             'url'    => 'http://www.dokuwiki.org/wiki:plugins',
         );
     }
- 
+
    /**
     * Get the type of syntax this plugin defines.
     *
@@ -78,7 +78,7 @@ class syntax_plugin_menu extends DokuWiki_Syntax_Plugin {
     function getType(){
         return 'protected';
     }
- 
+
    /**
     * Define how this plugin is handled regarding paragraphs.
     *
@@ -100,7 +100,7 @@ class syntax_plugin_menu extends DokuWiki_Syntax_Plugin {
     function getPType(){
         return 'block';
     }
- 
+
    /**
     * Where to sort in?
     *
@@ -114,7 +114,7 @@ class syntax_plugin_menu extends DokuWiki_Syntax_Plugin {
     function getSort(){
         return 135;
     }
- 
+
    /**
     * Connect lookup pattern to lexer.
     *
@@ -127,12 +127,12 @@ class syntax_plugin_menu extends DokuWiki_Syntax_Plugin {
        $this->Lexer->addEntryPattern('<menu>(?=.*?</menu.*?>)',$mode,'plugin_menu');
        $this->Lexer->addEntryPattern('<menu\s[^\r\n\|]*?>(?=.*?</menu.*?>)',$mode,'plugin_menu');
     }
- 
+
     function postConnect() {
       $this->Lexer->addPattern('<item>.+?</item>','plugin_menu');
       $this->Lexer->addExitPattern('</menu>','plugin_menu');
     }
- 
+
    /**
     * Handler to prepare matched data for the rendering process.
     *
@@ -165,7 +165,7 @@ class syntax_plugin_menu extends DokuWiki_Syntax_Plugin {
     function handle($match, $state, $pos, Doku_Handler $handler)
     {
         switch ($state) {
-            case DOKU_LEXER_ENTER: 
+            case DOKU_LEXER_ENTER:
                 $this->_reset();        // reset object;
 
                 $opts = $this->_parseOptions(trim(substr($match,5,-1)));
@@ -216,7 +216,7 @@ class syntax_plugin_menu extends DokuWiki_Syntax_Plugin {
         }
         return array();
     }
- 
+
     function _reset()
     {
         $this->rcmd = array();
@@ -231,7 +231,7 @@ class syntax_plugin_menu extends DokuWiki_Syntax_Plugin {
         // Split title from URL
         $link = explode('|',$link,2);
         $ref  = trim($link[0]);
-        
+
         //decide which kind of link it is
         if ( preg_match('/^[a-zA-Z0-9\.]+>{1}.*$/u',$ref) ) {
             // Interwiki
@@ -288,7 +288,7 @@ class syntax_plugin_menu extends DokuWiki_Syntax_Plugin {
         if (empty($data)) return false;
 
         if($mode == 'xhtml'){
-            if ($data['type'] != "menubar"){  
+            if ($data['type'] != "menubar"){
                     $renderer->doc .= '<div class="menu menu'.$data['float'].'"';
                     $renderer->doc .= ' style="width:' . $data['width'] . '">'."\n";
                     if (isset($data['caption']))
@@ -331,7 +331,7 @@ class syntax_plugin_menu extends DokuWiki_Syntax_Plugin {
                     return true;
             }
             // menubar mode: 1 row with small captions
-            if ($data['type'] == "menubar"){  
+            if ($data['type'] == "menubar"){
                     $renderer->doc .= '<div id="menu"><ul class="menubar">'."\n";
                   //  if (isset($data['caption']))
                   //      $renderer->doc .= '<p class="caption">'.$data['caption'].'</p>'."\n";

--- a/syntax.php
+++ b/syntax.php
@@ -175,6 +175,9 @@ class syntax_plugin_menu extends DokuWiki_Syntax_Plugin {
                 if ($opts['align'] == "left")   $this->rcmd['float'] = "left";
                 if ($opts['align'] == "center") $this->rcmd['float'] = "center";
                 if ($opts['align'] == "right")  $this->rcmd['float'] = "right";
+                if ($opts['valign'] == "top")   $this->rcmd['valign'] = "vtop";
+                if ($opts['valign'] == "center") $this->rcmd['valign'] = "vcenter";
+                if ($opts['valign'] == "bottom")  $this->rcmd['valign'] = "vbottom";
                 if (!empty($opts['caption']))
                     $this->rcmd['caption'] = hsc($opts['caption']);
                 if (!empty($opts['type']))
@@ -222,6 +225,7 @@ class syntax_plugin_menu extends DokuWiki_Syntax_Plugin {
         $this->rcmd = array();
         $this->rcmd['columns'] = 1;
         $this->rcmd['float']   = "left";
+        $this->rcmd['valign']  = "vtop";
     }
 
     function _itemlink($match, $title) {
@@ -289,7 +293,7 @@ class syntax_plugin_menu extends DokuWiki_Syntax_Plugin {
 
         if($mode == 'xhtml'){
             if ($data['type'] != "menubar"){
-                    $renderer->doc .= '<div class="menu menu'.$data['float'].'"';
+                    $renderer->doc .= '<div class="menu menu'.$data['float'].' menu'.$data['valign'].'"';
                     $renderer->doc .= ' style="width:' . $data['width'] . '">'."\n";
                     if (isset($data['caption']))
                         $renderer->doc .= '<p class="caption">'.$data['caption'].'</p>'."\n";


### PR DESCRIPTION
- Changed to flex positioning. This drops support for IE 9 and below, but fixes a lot of layout issues in various modes.
- Added width option. This makes it easier to define how the menu should look, since the automatic width determination didn't work well in many situations.
- Added wrap option. Recent changes broke a feature in the documentation, where "left" and "right" caused text to wrap around the menu. Using the "wrap" option re-enables this feature.
- Added valign option, which can be "top," "bottom" or "center." It positions the image relative to the text. Default is "top," to match current behavior.
- Menu now works with templates that don't have a hard-coded 42em width.
- A couple other minor bug fixes.

Tested with center, left and menubar.